### PR TITLE
feat: 감정 기록, 리포트 api 연동

### DIFF
--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,6 +1,7 @@
 import { Character } from "@/entities/character/model/character";
 import type { CharacterProps } from "@/entities/character/model/type";
 import { CharacterInfo } from "@/entities/character/ui";
+import { useInvalidateUserInfo } from "@/entities/user/model/userQueries";
 import { axiosInstance } from "@/shared/api/axios";
 import { useHideBottomNav } from "@/shared/hooks/useHideBottomNav";
 import { Button } from "@/shared/ui";
@@ -17,6 +18,7 @@ export default function Onboarding() {
 	);
 	const sele =
 		Character.findIndex((char) => char.name === selectedCharacter.name) + 1;
+	const invalidateUserInfo = useInvalidateUserInfo();
 
 	useHideBottomNav();
 
@@ -41,6 +43,7 @@ export default function Onboarding() {
 			});
 		},
 		onSuccess: () => {
+			invalidateUserInfo();
 			router.back();
 		},
 	});

--- a/app/record/index.tsx
+++ b/app/record/index.tsx
@@ -5,6 +5,7 @@ import {
 	EmotionWrite,
 } from "@/features/record/ui";
 import { useHideBottomNav } from "@/shared/hooks/useHideBottomNav";
+import { Toast } from "@/shared/ui";
 import { TopNav } from "@/widgets/TopNav/ui";
 
 export default function Record() {
@@ -40,7 +41,13 @@ export default function Record() {
 					setText={recordFlow.setText}
 					isFriendOnly={recordFlow.isFriendOnly}
 					setIsFriendOnly={recordFlow.setIsFriendOnly}
+					isSaving={recordFlow.isSaving}
 					OnSave={recordFlow.handleSave}
+				/>
+				<Toast
+					message={recordFlow.toastMessage}
+					visible={recordFlow.isToastVisible}
+					onHide={recordFlow.handleToastHide}
 				/>
 			</>
 		);

--- a/app/report/index.tsx
+++ b/app/report/index.tsx
@@ -1,70 +1,45 @@
-import { MonthlyEmotion } from "@/features/report/ui/MonthlyEmotion";
-import { PeakEmotionHours } from "@/features/report/ui/PeakEmotionHours";
-import { TopEmotion } from "@/features/report/ui/TopEmotion";
-import { CharacterBubble } from "@/shared/ui/CharacterBubble";
+import {
+	CharacterMessageBubble,
+	MonthlyEmotion,
+	PeakEmotionHours,
+	TopEmotion,
+} from "@/features/report/ui";
 import { TopNav } from "@/widgets/TopNav/ui";
 import { router } from "expo-router";
-import { View } from "react-native";
+import { ScrollView, View } from "react-native";
 
 export default function Report() {
 	return (
 		<>
 			<TopNav title="리포트" />
-			<View style={{ width: "100%", paddingHorizontal: 16 }}>
-				<CharacterBubble
-					character="츠츠"
-					message="3일 연속으로 기록을 남기고 있네? 
-이대로만 하자고."
-				/>
-				<MonthlyEmotion
-					emotion={{
-						mainColor: "#ff685b",
-						subColor: "#f3e9da",
-					}}
-					description="저번 달에 비해 '행복한' 키워드에 가까운 날이 더 많습니다."
-					onPress={() => {
-						router.push("/report/monthly-emotion");
-					}}
-				/>
-				<TopEmotion
-					emotionChip={[
-						{
-							label: "기쁨",
-							mainColor: "#FF685B",
-							subColor: "#063FB2",
-							count: 15,
-						},
-						{
-							label: "근심",
-							mainColor: "#063FB2",
-							subColor: "#8529D4",
-							count: 8,
-						},
-						{
-							label: "무기력",
-							mainColor: "#8529D4",
-							subColor: "#F3E9DA",
-							count: 5,
-						},
-						{
-							label: "초조",
-							mainColor: "#063FB2",
-							subColor: "#FF685B",
-							count: 3,
-						},
-						{
-							label: "초조",
-							mainColor: "#063FB2",
-							subColor: "#FF685B",
-							count: 1,
-						},
-					]}
-					onPress={() => {
-						router.push("/report/top-emotion");
-					}}
-				/>
-				<PeakEmotionHours description="주로 낮에 만족스러움 상태가 많았어요 " />
-			</View>
+			<ScrollView>
+				<View style={{ width: "100%", paddingHorizontal: 16 }}>
+					<CharacterMessageBubble />
+					<MonthlyEmotion
+						onPress={({ thisMonthEmotion, lastMonthEmotion }) => {
+							router.push({
+								pathname: "/report/monthly-emotion",
+								params: {
+									thisMonthEmotion,
+									lastMonthEmotion: lastMonthEmotion ?? "",
+								},
+							});
+						}}
+					/>
+					<TopEmotion
+						onPress={(emotions) => {
+							const emotionParam = encodeURIComponent(JSON.stringify(emotions));
+							router.push({
+								pathname: "/report/top-emotion",
+								params: {
+									emotions: emotionParam,
+								},
+							});
+						}}
+					/>
+					<PeakEmotionHours />
+				</View>
+			</ScrollView>
 		</>
 	);
 }

--- a/app/report/monthly-emotion/index.tsx
+++ b/app/report/monthly-emotion/index.tsx
@@ -1,11 +1,25 @@
 import { MonthlyEmotionChart } from "@/features/report/ui";
+import { useHideBottomNav } from "@/shared/hooks/useHideBottomNav";
 import { TopNav } from "@/widgets/TopNav/ui";
+import { useLocalSearchParams } from "expo-router";
 
 export default function MonthlyEmotionPage() {
+	useHideBottomNav();
+	const params = useLocalSearchParams<{
+		thisMonthEmotion: string;
+		lastMonthEmotion: string;
+	}>();
+
+	const thisMonthEmotion = params.thisMonthEmotion;
+	const lastMonthEmotion = params.lastMonthEmotion;
+
 	return (
 		<>
 			<TopNav title="저번 달과 상태 비교" leftIcon={true} />
-			<MonthlyEmotionChart thisMonthEmotion="기쁜" lastMonthEmotion="담담한" />
+			<MonthlyEmotionChart
+				thisMonthEmotion={thisMonthEmotion}
+				lastMonthEmotion={lastMonthEmotion}
+			/>
 		</>
 	);
 }

--- a/app/report/top-emotion/index.tsx
+++ b/app/report/top-emotion/index.tsx
@@ -1,53 +1,24 @@
 import { TopEmotionChart } from "@/features/report/ui/TopEmotionChart";
 import { useHideBottomNav } from "@/shared/hooks/useHideBottomNav";
+import type { EmotionChip } from "@/shared/types";
 import { TopNav } from "@/widgets/TopNav/ui";
+import { useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
 
 export default function TopEmotionPage() {
 	useHideBottomNav();
+	const params = useLocalSearchParams<{ emotions: string }>();
+
+	const emotionChip = useMemo(
+		() =>
+			JSON.parse(decodeURIComponent(params.emotions ?? "[]")) as EmotionChip[],
+		[params.emotions],
+	);
 
 	return (
 		<>
 			<TopNav title="제일 많았던 상태" leftIcon={true} />
-			<TopEmotionChart
-				emotionChip={[
-					{
-						label: "기쁨",
-						mainColor: "#FF685B",
-						subColor: "#063FB2",
-						count: 15,
-					},
-					{
-						label: "근심",
-						mainColor: "#063FB2",
-						subColor: "#8529D4",
-						count: 8,
-					},
-					{
-						label: "무기력",
-						mainColor: "#8529D4",
-						subColor: "#F3E9DA",
-						count: 5,
-					},
-					{
-						label: "초조",
-						mainColor: "#063FB2",
-						subColor: "#FF685B",
-						count: 3,
-					},
-					{
-						label: "초조",
-						mainColor: "#063FB2",
-						subColor: "#FF685B",
-						count: 1,
-					},
-					{
-						label: "초조",
-						mainColor: "#063FB2",
-						subColor: "#FF685B",
-						count: 1,
-					},
-				]}
-			/>
+			<TopEmotionChart emotionChip={emotionChip} />
 		</>
 	);
 }

--- a/entities/character/model/characterMessages.ts
+++ b/entities/character/model/characterMessages.ts
@@ -1,0 +1,11 @@
+export type CharacterName = "츠츠" | "루루" | "동동" | "티티" | "파파";
+
+export const CHARACTER_RECORD_MESSAGES: Record<CharacterName, string> = {
+	츠츠: "오늘 어땠는지 들어볼까?",
+	루루: "오늘 하루도 수고했어요. 어떤 감정이 스쳤나요?",
+	동동: "무슨 일 있었어요? 난 다 들어줄 준비됐어요.",
+	티티: "감정도 흐름이 있어. 그냥 느끼면 돼.",
+	파파: "흔들릴 때일수록 감정을 정리해두는 게 도움이 되지.",
+};
+
+export const DEFAULT_CHARACTER: CharacterName = "츠츠";

--- a/entities/user/model/userQueries.ts
+++ b/entities/user/model/userQueries.ts
@@ -1,0 +1,35 @@
+import type { CharacterName } from "@/entities/character/model/characterMessages";
+import { DEFAULT_CHARACTER } from "@/entities/character/model/characterMessages";
+import { getUserInfo } from "@/features/my/api/MyInfo";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+const USER_INFO_QUERY_KEY = ["userInfo"] as const;
+
+const CHARACTER_NAMES: readonly CharacterName[] = [
+	"츠츠",
+	"루루",
+	"동동",
+	"티티",
+	"파파",
+] as const;
+
+export function useUserCharacter() {
+	const { data } = useQuery({
+		queryKey: USER_INFO_QUERY_KEY,
+		queryFn: getUserInfo,
+		staleTime: 1000 * 60 * 5,
+	});
+
+	const apiName = data?.characterInfo?.name;
+
+	if (apiName && CHARACTER_NAMES.includes(apiName as CharacterName)) {
+		return apiName as CharacterName;
+	}
+
+	return DEFAULT_CHARACTER;
+}
+
+export function useInvalidateUserInfo() {
+	const queryClient = useQueryClient();
+	return () => queryClient.invalidateQueries({ queryKey: USER_INFO_QUERY_KEY });
+}

--- a/features/my/api/MyInfo.ts
+++ b/features/my/api/MyInfo.ts
@@ -17,12 +17,6 @@ export interface UserInfo {
 	characterInfo: CharacterInfo;
 }
 
-interface ApiResponse<T> {
-	success: boolean;
-	data: T;
-	message: string;
-}
-
 export const getUserInfo = async (): Promise<UserInfo> => {
 	const response = await axiosInstance.get<UserInfo>("/api/v1/users/me");
 	return response.data;

--- a/features/record/api/PostRecord.ts
+++ b/features/record/api/PostRecord.ts
@@ -1,0 +1,28 @@
+import { axiosInstance } from "@/shared/api/axios";
+
+interface PostRecordRequest {
+	record: string;
+	emotion_name: string;
+	main_color: string;
+	sub_color: string;
+	text_color: string;
+	is_shared: boolean;
+	ai_feedback_count: number;
+}
+
+interface PostRecordResponse {
+	code: number;
+	data: null;
+	message: string;
+}
+
+export const postRecord = async (
+	params: PostRecordRequest,
+): Promise<PostRecordResponse> => {
+	const response = await axiosInstance.post<PostRecordResponse>(
+		"/api/v1/emotion",
+		params,
+	);
+
+	return response.data;
+};

--- a/features/record/model/useRecordFlow.ts
+++ b/features/record/model/useRecordFlow.ts
@@ -1,7 +1,19 @@
+import { postRecord } from "@/features/record/api/PostRecord";
 import type { EmotionChip } from "@/shared/types";
+import { useMutation } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import { useState } from "react";
 
 type Phase = "explore" | "write" | "complete";
+
+interface PostRecordErrorResponse {
+	message: string;
+}
+
+const ERROR_MESSAGES: Record<number, string> = {
+	400: "잘못된 요청입니다.",
+	500: "서버 오류가 발생했습니다.",
+};
 
 export function useRecordFlow() {
 	const [phase, setPhase] = useState<Phase>("explore");
@@ -10,6 +22,40 @@ export function useRecordFlow() {
 	);
 	const [text, setText] = useState("");
 	const [isFriendOnly, setIsFriendOnly] = useState(false);
+	const [isToastVisible, setIsToastVisible] = useState(false);
+	const [toastMessage, setToastMessage] = useState("");
+
+	const { mutateAsync: postRecordMutate, isPending: isSaving } = useMutation<
+		Awaited<ReturnType<typeof postRecord>>,
+		AxiosError<PostRecordErrorResponse>,
+		Parameters<typeof postRecord>[0]
+	>({
+		mutationFn: postRecord,
+		onSuccess: () => {
+			setIsToastVisible(false);
+			setPhase("complete");
+		},
+		onError: (error) => {
+			const status = error.response?.status;
+			const message =
+				(status && ERROR_MESSAGES[status]) || "알 수 없는 오류가 발생했습니다.";
+
+			if (status === 500) {
+				setToastMessage(`${message} 다시 시도해주세요.`);
+				setIsToastVisible(true);
+				return;
+			}
+
+			if (status === 400) {
+				setToastMessage(message);
+				setIsToastVisible(true);
+				return;
+			}
+
+			setToastMessage("기록 저장 실패");
+			setIsToastVisible(true);
+		},
+	});
 
 	const handleProceedToWrite = (chip: EmotionChip) => {
 		setSelectedEmotion(chip);
@@ -17,13 +63,35 @@ export function useRecordFlow() {
 	};
 
 	const handleSave = async () => {
-		console.log({
-			emotion: selectedEmotion,
-			text,
-			isFriendOnly,
-			textColor: selectedEmotion?.textColor,
-		});
-		setPhase("complete");
+		if (!selectedEmotion) {
+			setToastMessage("감정을 먼저 선택해주세요.");
+			setIsToastVisible(true);
+			return;
+		}
+
+		const label = selectedEmotion.label;
+
+		if (!label) {
+			setToastMessage("선택한 감정에 이름이 없습니다.");
+			setIsToastVisible(true);
+			return;
+		}
+
+		const payload = {
+			record: text,
+			emotion_name: label,
+			main_color: selectedEmotion.mainColor,
+			sub_color: selectedEmotion.subColor,
+			text_color: selectedEmotion.textColor ?? "#FFFFFF",
+			is_shared: isFriendOnly,
+			ai_feedback_count: 1,
+		};
+
+		try {
+			await postRecordMutate(payload);
+		} catch (error) {
+			console.log(error);
+		}
 	};
 
 	const handleBack = () => {
@@ -42,5 +110,9 @@ export function useRecordFlow() {
 		handleProceedToWrite,
 		handleSave,
 		handleBack,
+		isSaving,
+		isToastVisible,
+		toastMessage,
+		handleToastHide: () => setIsToastVisible(false),
 	};
 }

--- a/features/record/ui/EmotionComplete.tsx
+++ b/features/record/ui/EmotionComplete.tsx
@@ -1,3 +1,4 @@
+import { useUserCharacter } from "@/entities/user/model/userQueries";
 import * as S from "@/features/record/style/EmotionComplete.styles";
 import type { EmotionChip } from "@/shared/types";
 import { CharacterBubble } from "@/shared/ui/CharacterBubble";
@@ -19,7 +20,7 @@ const getCharacterMessage = (characterName: string): string => {
 export const EmotionComplete: React.FC<EmotionCompleteProps> = ({
 	selectedEmotion,
 }) => {
-	const characterName = "츠츠";
+	const userCharacter = useUserCharacter();
 	const router = useRouter();
 	const fade1 = useRef(new Animated.Value(0)).current;
 	const fade2 = useRef(new Animated.Value(0)).current;
@@ -64,8 +65,8 @@ export const EmotionComplete: React.FC<EmotionCompleteProps> = ({
 			)}
 			<Animated.View style={{ opacity: fade3 }}>
 				<CharacterBubble
-					character={characterName}
-					message={getCharacterMessage(characterName)}
+					character={userCharacter}
+					message={getCharacterMessage(userCharacter)}
 				/>
 			</Animated.View>
 		</S.Container>

--- a/features/record/ui/EmotionWrite.tsx
+++ b/features/record/ui/EmotionWrite.tsx
@@ -1,3 +1,5 @@
+import { CHARACTER_RECORD_MESSAGES } from "@/entities/character/model/characterMessages";
+import { useUserCharacter } from "@/entities/user/model/userQueries";
 import * as S from "@/features/record/style/EmotionWrite.styles";
 import type { EmotionChip } from "@/shared/types";
 import { Button, Switch, TextInput } from "@/shared/ui";
@@ -11,6 +13,7 @@ interface EmotionWriteProps {
 	setText?: (text: string) => void;
 	isFriendOnly: boolean;
 	setIsFriendOnly: (value: boolean) => void;
+	isSaving: boolean;
 	OnSave: () => void;
 }
 
@@ -20,13 +23,17 @@ export const EmotionWrite: React.FC<EmotionWriteProps> = ({
 	setText,
 	isFriendOnly,
 	setIsFriendOnly,
+	isSaving = false,
 	OnSave,
-}) => {
+}: EmotionWriteProps) => {
+	const userCharacter = useUserCharacter();
+	const activeCharacter = userCharacter;
+	const message = CHARACTER_RECORD_MESSAGES[activeCharacter];
 	return (
 		<S.Container>
 			<CharacterBubble
-				character="츠츠"
-				message="오늘 어땠는지 들어볼까?"
+				character={activeCharacter}
+				message={message}
 				enableTypewriter
 			/>
 			<S.EmotionWrapper>
@@ -54,7 +61,7 @@ export const EmotionWrite: React.FC<EmotionWriteProps> = ({
 				size="large"
 				text="완료"
 				color="white"
-				disabled={!text}
+				disabled={!text || isSaving}
 				onPress={OnSave}
 			/>
 		</S.Container>

--- a/features/report/api/GetCharacterMessage.ts
+++ b/features/report/api/GetCharacterMessage.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from "@/shared/api/axios";
+
+interface CharacterMessageResponse {
+	character_name: string;
+	message: string;
+}
+
+export async function getCharacterMessage() {
+	return axiosInstance.post<CharacterMessageResponse>(
+		"/api/v1/emotion/report/character-message",
+	);
+}

--- a/features/report/api/GetComparison.ts
+++ b/features/report/api/GetComparison.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "@/shared/api/axios";
+
+export interface ComparisonSection {
+	representative_emotion: string;
+	main_color: string;
+	sub_color: string;
+}
+
+export interface ComparisonResponse {
+	thisMonth: ComparisonSection;
+	lastMonth: ComparisonSection;
+}
+
+export async function getComparison() {
+	return axiosInstance.get<ComparisonResponse>(
+		"/api/v1/emotion/report/comparison",
+	);
+}

--- a/features/report/api/GetPeakHours.ts
+++ b/features/report/api/GetPeakHours.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from "@/shared/api/axios";
+
+export interface PeakHoursResponse {
+	dominant_time: string;
+	dominant_emotion: string;
+}
+
+export async function getPeakHours() {
+	return axiosInstance.get<PeakHoursResponse>(
+		"/api/v1/emotion/report/time-pattern",
+	);
+}

--- a/features/report/api/GetTopEmotion.ts
+++ b/features/report/api/GetTopEmotion.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "@/shared/api/axios";
+
+export interface TopEmotionItem {
+	emotion_name: string;
+	count: number;
+	main_color: string;
+	sub_color: string;
+}
+
+export interface TopEmotionsResponse {
+	emotions: TopEmotionItem[];
+}
+
+export async function getTopEmotions() {
+	return axiosInstance.get<TopEmotionsResponse>(
+		"/api/v1/emotion/report/top-emotions",
+	);
+}

--- a/features/report/style/TopEmotion.styles.ts
+++ b/features/report/style/TopEmotion.styles.ts
@@ -33,6 +33,11 @@ export const Label = styled.Text`
   color: ${({ theme }) => theme.grayscale.gray50};
 `;
 
+export const Description = styled.Text`
+  ${({ theme }) => theme.typography["title2-medium"]};
+  color: ${({ theme }) => theme.grayscale.white};
+`;
+
 export const EmotionWrapper = styled.View`
   width: 100%;
   flex-direction: column;

--- a/features/report/ui/CharacterMessageBubble.tsx
+++ b/features/report/ui/CharacterMessageBubble.tsx
@@ -1,0 +1,36 @@
+import type { CharacterName } from "@/entities/character/model/characterMessages";
+import { getCharacterMessage } from "@/features/report/api/GetCharacterMessage";
+import { CharacterBubble } from "@/shared/ui/CharacterBubble";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+export const CharacterMessageBubble: React.FC = () => {
+	const [characterName, setCharacterName] = useState<CharacterName>("츠츠");
+	const [message, setMessage] = useState<string>("...");
+
+	const characterMessageMutation = useMutation({
+		mutationFn: getCharacterMessage,
+		onSuccess: (response) => {
+			const payload = response.data;
+
+			if (payload?.character_name) {
+				setCharacterName(payload.character_name as CharacterName);
+			} else {
+				setCharacterName("츠츠");
+			}
+
+			setMessage(payload?.message ?? "생각하는 중...");
+		},
+		onError: (error) => {
+			console.error(error);
+			setCharacterName("츠츠");
+			setMessage("생각하는 중...");
+		},
+	});
+
+	useEffect(() => {
+		characterMessageMutation.mutate();
+	}, [characterMessageMutation.mutate]);
+
+	return <CharacterBubble character={characterName} message={message} />;
+};

--- a/features/report/ui/MonthlyEmotion.tsx
+++ b/features/report/ui/MonthlyEmotion.tsx
@@ -1,30 +1,112 @@
+import {
+	getComparison,
+	type ComparisonSection,
+} from "@/features/report/api/GetComparison";
 import * as S from "@/features/report/style/MonthlyEmotion.styles";
 import RightIcon from "@/shared/assets/icons/right.svg";
 import { theme } from "@/shared/config/theme/theme";
-import type { EmotionChip } from "@/shared/types";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { TouchableOpacity } from "react-native";
 
-interface MonthlyEmotionProps {
-	emotion: Pick<EmotionChip, "mainColor" | "subColor">;
-	description: string;
-	onPress: () => void;
+interface MonthlyEmotionParams {
+	thisMonthEmotion: string;
+	lastMonthEmotion: string | null;
 }
 
-export const MonthlyEmotion: React.FC<MonthlyEmotionProps> = ({
-	emotion,
-	description,
-	onPress,
-}) => {
+interface MonthlyEmotionProps {
+	onPress: (params: MonthlyEmotionParams) => void;
+}
+
+interface ComparisonData {
+	thisMonth: ComparisonSection;
+	lastMonth: ComparisonSection | null;
+}
+
+export const MonthlyEmotion: React.FC<MonthlyEmotionProps> = ({ onPress }) => {
+	const [comparison, setComparison] = useState<ComparisonData | null>(null);
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+
+	const comparisonMutation = useMutation({
+		mutationFn: getComparison,
+		onSuccess: (comparisonData) => {
+			const extractEmotion = (section?: ComparisonSection | null) =>
+				section && section.representative_emotion !== "없음" ? section : null;
+
+			const thisMonth = extractEmotion(comparisonData.data.thisMonth);
+			const lastMonth = extractEmotion(comparisonData.data.lastMonth);
+
+			setComparison(
+				thisMonth
+					? {
+							thisMonth,
+							lastMonth,
+						}
+					: null,
+			);
+
+			setIsLoading(false);
+		},
+		onError: (error) => {
+			console.error(error);
+			setIsLoading(false);
+		},
+	});
+
+	useEffect(() => {
+		comparisonMutation.mutate();
+	}, [comparisonMutation.mutate]);
+
+	if (isLoading) {
+		return (
+			<S.Container>
+				<S.TopWrapper>
+					<S.Title>저번 달과 상태 비교</S.Title>
+				</S.TopWrapper>
+				<S.Description>...</S.Description>
+			</S.Container>
+		);
+	}
+
+	if (!comparison) {
+		return (
+			<S.Container>
+				<S.TopWrapper>
+					<S.Title>저번 달과 상태 비교</S.Title>
+				</S.TopWrapper>
+				<S.Description>기록을 남기면 확인할 수 있어요.</S.Description>
+			</S.Container>
+		);
+	}
+
+	const { thisMonth: thisMonthComparison, lastMonth: lastMonthComparison } =
+		comparison;
+
 	return (
 		<S.Container>
 			<S.TopWrapper>
 				<S.Title>저번 달과 상태 비교</S.Title>
-				<TouchableOpacity onPress={onPress}>
+				<TouchableOpacity
+					onPress={() =>
+						onPress({
+							thisMonthEmotion: thisMonthComparison.representative_emotion,
+							lastMonthEmotion:
+								lastMonthComparison?.representative_emotion ?? null,
+						})
+					}
+				>
 					<RightIcon width={18} height={18} color={theme.grayscale.gray200} />
 				</TouchableOpacity>
 			</S.TopWrapper>
-			<S.EmotionBox mainColor={emotion.mainColor} subColor={emotion.subColor} />
-			<S.Description>{description}</S.Description>
+			<S.EmotionBox
+				mainColor={thisMonthComparison.main_color}
+				subColor={thisMonthComparison.sub_color}
+			/>
+			<S.Description>
+				{isLoading
+					? "..."
+					: `저번 달에 비해 '${comparison.thisMonth.representative_emotion}' 키워드에 가까운 날이 더 많습니다.`}
+			</S.Description>
 		</S.Container>
 	);
 };

--- a/features/report/ui/PeakEmotionHours.tsx
+++ b/features/report/ui/PeakEmotionHours.tsx
@@ -1,18 +1,52 @@
+import {
+	getPeakHours,
+	type PeakHoursResponse,
+} from "@/features/report/api/GetPeakHours";
 import * as S from "@/features/report/style/PeakEmotionHours.styles";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
-interface PeakEmotionHoursProps {
-	description: string;
-}
+export const PeakEmotionHours: React.FC = () => {
+	const [peakEmotion, setPeakEmotion] = useState<PeakHoursResponse | null>(
+		null,
+	);
+	const [isLoading, setIsLoading] = useState<boolean>(true);
 
-export const PeakEmotionHours: React.FC<PeakEmotionHoursProps> = ({
-	description,
-}) => {
+	const peakEmotionMutation = useMutation({
+		mutationFn: getPeakHours,
+		onSuccess: (peakData) => {
+			setPeakEmotion(peakData.data);
+			setIsLoading(false);
+		},
+		onError: (error) => {
+			console.error(error);
+			setPeakEmotion(null);
+			setIsLoading(false);
+		},
+	});
+
+	useEffect(() => {
+		peakEmotionMutation.mutate();
+	}, [peakEmotionMutation.mutate]);
+
+	const renderDescription = () => {
+		if (isLoading) {
+			return "...";
+		}
+
+		if (!peakEmotion || peakEmotion.dominant_time === "없음") {
+			return "기록을 남기면 확인할 수 있어요.";
+		}
+
+		return `주로 ${peakEmotion.dominant_time}에 '${peakEmotion.dominant_emotion}' 상태가 많았어요.`;
+	};
+
 	return (
 		<S.Container>
 			<S.TopWrapper>
 				<S.Title>특정 상태가 많았던 시간대</S.Title>
 			</S.TopWrapper>
-			<S.Description>{description}</S.Description>
+			<S.Description>{renderDescription()}</S.Description>
 		</S.Container>
 	);
 };

--- a/features/report/ui/TopEmotion.tsx
+++ b/features/report/ui/TopEmotion.tsx
@@ -1,40 +1,91 @@
+import {
+	getTopEmotions,
+	type TopEmotionItem,
+} from "@/features/report/api/GetTopEmotion";
 import * as S from "@/features/report/style/TopEmotion.styles";
 import RightIcon from "@/shared/assets/icons/right.svg";
 import { theme } from "@/shared/config/theme/theme";
 import type { EmotionChip } from "@/shared/types";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { TouchableOpacity } from "react-native";
 
 interface TopEmotionProps {
-	emotionChip: EmotionChip[];
-	onPress: () => void;
+	onPress: (emotions: TopEmotionChip[]) => void;
 }
 
-export const TopEmotion: React.FC<TopEmotionProps> = ({
-	emotionChip,
-	onPress,
-}) => {
+interface TopEmotionChip extends EmotionChip {
+	label: string;
+	count: number;
+}
+
+export const TopEmotion: React.FC<TopEmotionProps> = ({ onPress }) => {
+	const [emotionChip, setEmotionChip] = useState<TopEmotionChip[]>([]);
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+
+	const topEmotionMutation = useMutation({
+		mutationFn: getTopEmotions,
+		onSuccess: (data) => {
+			const topEmotions = data.data;
+			const mapped = topEmotions.emotions.map((emotion: TopEmotionItem) => ({
+				label:
+					emotion.emotion_name && emotion.emotion_name !== "없음"
+						? emotion.emotion_name.replace(/_/g, " ")
+						: "없음",
+				count: emotion.count,
+				mainColor: emotion.main_color,
+				subColor: emotion.sub_color,
+			}));
+
+			setEmotionChip(mapped);
+			setIsLoading(false);
+		},
+		onError: (error) => {
+			console.error(error);
+			setEmotionChip([]);
+			setIsLoading(false);
+		},
+	});
+
+	useEffect(() => {
+		topEmotionMutation.mutate();
+	}, [topEmotionMutation.mutate]);
+
 	return (
 		<S.Container>
 			<S.TopWrapper>
 				<S.Title>제일 많았던 상태</S.Title>
-				<TouchableOpacity onPress={onPress}>
-					<RightIcon width={18} height={18} color={theme.grayscale.gray200} />
-				</TouchableOpacity>
+				{emotionChip.length > 0 && (
+					<TouchableOpacity
+						onPress={() => {
+							if (isLoading || emotionChip.length === 0) return;
+							onPress(emotionChip);
+						}}
+					>
+						<RightIcon width={18} height={18} color={theme.grayscale.gray200} />
+					</TouchableOpacity>
+				)}
 			</S.TopWrapper>
 
 			<S.EmotionWrapper>
-				{emotionChip.slice(0, 5).map((chip, index) => (
-					<S.EmotionList key={`${chip.label}-${index}`}>
-						<S.Label>{chip.label}</S.Label>
-						<S.RightCol>
-							<S.Count>{chip.count}</S.Count>
-							<S.EmotionBox
-								mainColor={chip.mainColor}
-								subColor={chip.subColor}
-							/>
-						</S.RightCol>
-					</S.EmotionList>
-				))}
+				{isLoading ? (
+					<S.Label>...</S.Label>
+				) : emotionChip.length === 0 ? (
+					<S.Description>기록을 남기면 확인할 수 있어요.</S.Description>
+				) : (
+					emotionChip.slice(0, 5).map((chip, index) => (
+						<S.EmotionList key={`${chip.label}-${index}`}>
+							<S.Label>{chip.label}</S.Label>
+							<S.RightCol>
+								<S.Count>{chip.count}</S.Count>
+								<S.EmotionBox
+									mainColor={chip.mainColor}
+									subColor={chip.subColor}
+								/>
+							</S.RightCol>
+						</S.EmotionList>
+					))
+				)}
 			</S.EmotionWrapper>
 		</S.Container>
 	);

--- a/features/report/ui/TopEmotionChart.tsx
+++ b/features/report/ui/TopEmotionChart.tsx
@@ -2,11 +2,11 @@ import * as S from "@/features/report/style/TopEmotionChart.styles";
 import type { EmotionChip } from "@/shared/types";
 
 interface TopEmotionChartProps {
-	emotionChip: EmotionChip[];
+	emotionChip?: EmotionChip[];
 }
 
 export const TopEmotionChart: React.FC<TopEmotionChartProps> = ({
-	emotionChip,
+	emotionChip = [],
 }) => {
 	return (
 		<S.Container>
@@ -15,7 +15,7 @@ export const TopEmotionChart: React.FC<TopEmotionChartProps> = ({
 					<S.EmotionList key={`${chip.label}-${index}`}>
 						<S.Label>{chip.label}</S.Label>
 						<S.RightCol>
-							<S.Count>{chip.count}</S.Count>
+							<S.Count>{chip.count ?? 0}</S.Count>
 							<S.EmotionBox
 								mainColor={chip.mainColor}
 								subColor={chip.subColor}

--- a/features/report/ui/index.ts
+++ b/features/report/ui/index.ts
@@ -1,5 +1,6 @@
 export { MonthlyEmotion } from "@/features/report/ui/MonthlyEmotion";
 export { MonthlyEmotionChart } from "@/features/report/ui/MonthlyEmotionChart";
+export { CharacterMessageBubble } from "@/features/report/ui/CharacterMessageBubble";
 export { PeakEmotionHours } from "@/features/report/ui/PeakEmotionHours";
 export { TopEmotion } from "@/features/report/ui/TopEmotion";
 export { TopEmotionChart } from "@/features/report/ui/TopEmotionChart";

--- a/shared/style/Toast.styles.ts
+++ b/shared/style/Toast.styles.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components/native";
+import { Animated } from "react-native";
+
+export const Container = styled.View`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: ${({ theme }) => theme.rem(80)};
+  align-items: center;
+`;
+
+export const ToastWrapper = styled(Animated.View)`
+  max-width: 80%;
+  padding: ${({ theme }) => theme.rem(12)} ${({ theme }) => theme.rem(16)};
+  border-radius: ${({ theme }) => theme.rem(24)};
+  background-color: rgba(16, 16, 16, 0.9);
+`;
+
+export const ToastText = styled(Animated.Text)`
+  color: #ffffff;
+  font-size: ${({ theme }) => theme.rem(14)};
+  text-align: center;
+`;

--- a/shared/ui/CharacterBubble.tsx
+++ b/shared/ui/CharacterBubble.tsx
@@ -1,8 +1,7 @@
 import * as S from "@/shared/style/CharacterBubble.style";
+import type { CharacterName } from "@/entities/character/model/characterMessages";
 import type { ImageSourcePropType } from "react-native";
 import TypeWriter from "react-native-typewriter-effect";
-
-type CharacterName = "츠츠" | "루루" | "동동" | "티티" | "파파";
 
 interface CharacterBubbleProps {
 	character: CharacterName;

--- a/shared/ui/Toast.tsx
+++ b/shared/ui/Toast.tsx
@@ -1,0 +1,80 @@
+import * as S from "@/shared/style/Toast.styles";
+import { useEffect, useRef } from "react";
+import { Animated } from "react-native";
+
+interface ToastProps {
+	message: string;
+	visible: boolean;
+	duration?: number;
+	onHide: () => void;
+}
+
+export function Toast({
+	message,
+	visible,
+	duration = 2000,
+	onHide,
+}: ToastProps) {
+	const opacity = useRef(new Animated.Value(0)).current;
+	const translateY = useRef(new Animated.Value(20)).current;
+
+	useEffect(() => {
+		let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+		if (visible) {
+			Animated.parallel([
+				Animated.timing(opacity, {
+					toValue: 1,
+					duration: 200,
+					useNativeDriver: true,
+				}),
+				Animated.timing(translateY, {
+					toValue: 0,
+					duration: 200,
+					useNativeDriver: true,
+				}),
+			]).start();
+
+			hideTimer = setTimeout(() => {
+				Animated.parallel([
+					Animated.timing(opacity, {
+						toValue: 0,
+						duration: 200,
+						useNativeDriver: true,
+					}),
+					Animated.timing(translateY, {
+						toValue: 20,
+						duration: 200,
+						useNativeDriver: true,
+					}),
+				]).start(onHide);
+			}, duration);
+		} else {
+			opacity.setValue(0);
+			translateY.setValue(20);
+		}
+
+		return () => {
+			if (hideTimer) {
+				clearTimeout(hideTimer);
+			}
+		};
+	}, [duration, onHide, opacity, translateY, visible]);
+
+	if (!visible) {
+		return null;
+	}
+
+	return (
+		<S.Container pointerEvents="none">
+			<S.ToastWrapper
+				style={{
+					opacity,
+					transform: [{ translateY }],
+				}}
+			>
+				<S.ToastText>{message}</S.ToastText>
+			</S.ToastWrapper>
+		</S.Container>
+	);
+}

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -13,3 +13,4 @@ export * from "@/shared/ui/Popover";
 export * from "@/shared/ui/ProfileButton";
 export * from "@/shared/ui/Switch";
 export * from "@/shared/ui/TextInput";
+export * from "@/shared/ui/Toast";


### PR DESCRIPTION
## 🔥 PR 제목  
feat: 감정 기록, 리포트 api 연동

## 📌 작업 내용  
- 감정 기록 api 연동
- 리포트 api 연동
- 유저 정보 내 캐릭터 가져오는 훅 (감정 기록 내 ai캐릭터에서 사용)
* 리포트에서 ai 캐릭터 글이 긴데 한두문장내로 나올 수 있게 프롬프트 수정 요청드렸습니다

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-12 at 21 18 03" src="https://github.com/user-attachments/assets/6067a270-8d20-47ce-88d3-6e41d401ab79" />
<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-12 at 22 02 15" src="https://github.com/user-attachments/assets/5244c867-b454-468e-a562-d5e7c4c6f313" />


## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  
