### PR TITLE
feat: 피드백 대기 중 캐릭터 유지

### DIFF
--- a/features/home/ui/TodayHistory.tsx
+++ b/features/home/ui/TodayHistory.tsx
@@ -5,6 +5,7 @@ import * as S from "@/features/home/style/TodayHistory.styles";
 import { getRecordById } from "@/features/record/api/getRecordById";
 import { useFeedbackTimer } from "@/shared/hooks/useFeedbackTimer";
 import { useAuthStore } from "@/shared/store/auth";
+import { useFeedbackTimerStore } from "@/shared/store/feedbackTimer";
 import { MyCharacter } from "@/shared/store/myCharacter";
 import { EmotionCard } from "@/shared/ui/EmotionCard";
 import { useQuery } from "@tanstack/react-query";
@@ -19,6 +20,7 @@ import {
 	TouchableOpacity,
 	View,
 } from "react-native";
+
 interface TodayHistoryProps {
 	recordId: number;
 	onMenuPress: () => void;
@@ -30,6 +32,7 @@ export function TodayHistory({ recordId, onMenuPress }: TodayHistoryProps) {
 	const journalIdString = String(recordId);
 	const { isWaitingForFeedback, remainingSeconds } =
 		useFeedbackTimer(journalIdString);
+	const { characterName: savedCharacterName } = useFeedbackTimerStore();
 	const { name: currentCharacterName } = MyCharacter();
 	const { data: record, isLoading: isRecordLoading } = useQuery({
 		queryKey: ["emotionRecord", recordId],
@@ -110,21 +113,25 @@ export function TodayHistory({ recordId, onMenuPress }: TodayHistoryProps) {
 	]);
 
 	const characterImage = useMemo(() => {
-		if (isWaitingForFeedback) {
-			return getCharacterImage(currentCharacterName as CharacterName);
+		if (isWaitingForFeedback || isFeedbackLoading) {
+			const characterToShow = savedCharacterName || currentCharacterName;
+			return getCharacterImage(characterToShow as CharacterName);
 		}
-		if (!feedbackData?.characterName) {
-			return getCharacterImage("츠츠");
-		}
-		return getCharacterImage(feedbackData.characterName as CharacterName);
-	}, [feedbackData?.characterName, currentCharacterName, isWaitingForFeedback]);
+		return getCharacterImage(feedbackData?.characterName as CharacterName);
+	}, [
+		feedbackData?.characterName,
+		currentCharacterName,
+		isWaitingForFeedback,
+		isFeedbackLoading,
+		savedCharacterName,
+	]);
 
 	const displayAIComment = useMemo(() => {
 		if (isWaitingForFeedback) {
 			return `기록을 읽고 답장을 쓰는 중... (${remainingSeconds}초)`;
 		}
 		if (isFeedbackLoading) {
-			return "피드백을 생성하고 있습니다...";
+			return "답장을 가져오는 중...";
 		}
 		return feedbackData?.aiReply || "오늘 하루도 수고했어.";
 	}, [isWaitingForFeedback, remainingSeconds, isFeedbackLoading, feedbackData]);

--- a/features/record/model/useRecordFlow.ts
+++ b/features/record/model/useRecordFlow.ts
@@ -5,6 +5,7 @@ import {
 	useFeedbackTimerActions,
 	useFeedbackTimerStore,
 } from "@/shared/store/feedbackTimer";
+import { MyCharacter } from "@/shared/store/myCharacter";
 import type { EmotionChip } from "@/shared/types";
 import { useMutation } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
@@ -75,7 +76,8 @@ export function useRecordFlow() {
 			onSuccess: (data) => {
 				setIsToastVisible(false);
 				feedbackMutate(data.record_id);
-				startTimer(data.record_id.toString(), 60);
+				const { name: currentCharacterName } = MyCharacter.getState();
+				startTimer(data.record_id.toString(), 60, currentCharacterName);
 				setPhase("complete");
 			},
 			onError: (error) => {
@@ -155,7 +157,8 @@ export function useRecordFlow() {
 			}
 
 			feedbackMutate(updatedRecordId);
-			startTimer(updatedRecordId.toString(), 60);
+			const { name: currentCharacterName } = MyCharacter.getState();
+			startTimer(updatedRecordId.toString(), 60, currentCharacterName);
 		}
 		setShowConfirmModal(false);
 		setPhase("complete");

--- a/shared/store/feedbackTimer.ts
+++ b/shared/store/feedbackTimer.ts
@@ -4,8 +4,13 @@ interface FeedbackTimerState {
 	isTimerRunning: boolean;
 	targetJournalId: string | null;
 	timerEndTime: number | null;
+	characterName: string | null;
 	actions: {
-		startTimer: (journalId: string, durationInSeconds: number) => void;
+		startTimer: (
+			journalId: string,
+			durationInSeconds: number,
+			characterName: string,
+		) => void;
 		clearTimer: () => void;
 	};
 }
@@ -14,18 +19,21 @@ export const useFeedbackTimerStore = create<FeedbackTimerState>((set) => ({
 	isTimerRunning: false,
 	targetJournalId: null,
 	timerEndTime: null,
+	characterName: null,
 	actions: {
-		startTimer: (journalId, durationInSeconds) =>
+		startTimer: (journalId, durationInSeconds, characterName) =>
 			set({
 				isTimerRunning: true,
 				targetJournalId: journalId,
 				timerEndTime: Date.now() + durationInSeconds * 1000,
+				characterName,
 			}),
 		clearTimer: () =>
 			set({
 				isTimerRunning: false,
 				targetJournalId: null,
 				timerEndTime: null,
+				characterName: null,
 			}),
 	},
 }));


### PR DESCRIPTION
## 🔥 PR 제목  
feat: 피드백 대기 중 캐릭터 유지

## 📌 작업 내용  
> [문제 상황]
> 사용자가 기록 생성 후 캐릭터를 변경하면, 피드백 대기 중에 변경된 캐릭터가 표시되는 문제 발생
> 예: 루루로 기록 생성 → 츠츠로 캐릭터 변경 → 피드백 대기 중 츠츠가 표시됨 (루루가 표시되어야 함)

- 피드백 타이머에 캐릭터 정보 추가
- 기록 생성 시점의 캐릭터 저장 -> 피드백 재요청 시에도 동일하게
- 피드백 대기 중 저장된 캐릭터 표시

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
<img width="368" height="632" alt="image" src="https://github.com/user-attachments/assets/4441dbd0-bd1c-4643-a00c-1f03aa41abce" />

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  
