### PR TITLE
feat: 새 유저 온보딩 플로우 개선

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -153,7 +153,7 @@ function RootLayoutNav() {
 			return false;
 		};
 
-		setupNotifications().then((navigationHandledByNotification) => {
+		setupNotifications().then(async (navigationHandledByNotification) => {
 			SplashScreen.hideAsync();
 			if (navigationHandledByNotification) {
 				return;
@@ -171,15 +171,27 @@ function RootLayoutNav() {
 
 			const inAuthGroup = pathname.startsWith("/login");
 
-			if (isLoggedIn && inAuthGroup && !isOnboarding) {
+			let currentIsOnboarding = isOnboarding;
+			if (isLoggedIn) {
+				const isOnboardingNeeded =
+					await AsyncStorage.getItem("isOnboardingNeeded");
+				currentIsOnboarding = isOnboardingNeeded === "true";
+				if (currentIsOnboarding !== isOnboarding) {
+					setIsOnboarding(currentIsOnboarding);
+				}
+			}
+
+			if (isLoggedIn && inAuthGroup && !currentIsOnboarding) {
 				router.replace("/home");
+				return;
 			}
 
-			if (isLoggedIn && isOnboarding && pathname !== "/onboarding") {
+			if (isLoggedIn && currentIsOnboarding && pathname !== "/onboarding") {
 				router.replace("/onboarding");
+				return;
 			}
 
-			if (!isLoggedIn && !inAuthGroup && !isOnboarding) {
+			if (!isLoggedIn && !inAuthGroup && !currentIsOnboarding) {
 				router.replace("/login");
 			}
 		});
@@ -195,6 +207,7 @@ function RootLayoutNav() {
 		router,
 		showToast,
 		navigationRef,
+		setIsOnboarding,
 	]);
 
 	if (!loaded || !rootState?.key || isLoggedIn === null) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -161,11 +161,9 @@ function RootLayoutNav() {
 			}
 
 			const inAuthGroup = pathname.startsWith("/login");
+			const isOnboarding = pathname.startsWith("/onboarding");
 
-			if (isLoggedIn && inAuthGroup) {
-				router.replace("/home");
-			}
-			if (!isLoggedIn && !inAuthGroup) {
+			if (!isLoggedIn && !inAuthGroup && !isOnboarding) {
 				router.replace("/login");
 			}
 		});

--- a/app/home/index.tsx
+++ b/app/home/index.tsx
@@ -6,6 +6,7 @@ import {
 	deleteEmotionRecord,
 	getEmotionRecord,
 } from "@/features/journal/api/emotion";
+import { getUserInfo } from "@/features/my/api/MyInfo";
 import { NotificationBell } from "@/features/notifications/ui/NotificationBell";
 import { useAuthStore } from "@/shared/store/auth";
 import { MyCharacter } from "@/shared/store/myCharacter";
@@ -41,7 +42,7 @@ export default function Home() {
 	const today = getTodayKST();
 	const queryClient = useQueryClient();
 	const { isLoggedIn } = useAuthStore();
-	const { name } = MyCharacter();
+	const { name, setName } = MyCharacter();
 
 	const [selectedDate, setSelectedDate] = useState<string>(today);
 	const [currentMonth, setCurrentMonth] = useState<string>(today.slice(0, 7));
@@ -112,6 +113,20 @@ export default function Home() {
 			console.error("Error deleting record:", error);
 		},
 	});
+
+	const { data: userInfo } = useQuery({
+		queryKey: ["userInfo"],
+		queryFn: getUserInfo,
+		enabled: !!isLoggedIn,
+	});
+
+	useEffect(() => {
+		if (userInfo?.characterInfo?.name) {
+			if (name !== userInfo.characterInfo.name) {
+				setName(userInfo.characterInfo.name);
+			}
+		}
+	}, [userInfo, name, setName]);
 
 	useEffect(() => {
 		show();

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -5,14 +5,15 @@ import { useInvalidateUserInfo } from "@/entities/user/model/userQueries";
 import { axiosInstance } from "@/shared/api/axios";
 import { useHideBottomNav } from "@/shared/hooks/useHideBottomNav";
 import { usePreloadAssets } from "@/shared/hooks/usePreloadAssets";
+import { useAuthStore } from "@/shared/store/auth";
 import { MyCharacter } from "@/shared/store/myCharacter";
 import { Button } from "@/shared/ui";
 import { TopNav } from "@/widgets/TopNav/ui";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useMutation } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { ActivityIndicator, View } from "react-native";
-
 const characterImages = Character.map((char) => char.image);
 
 export default function Onboarding() {
@@ -26,6 +27,7 @@ export default function Onboarding() {
 	const sele =
 		Character.findIndex((char) => char.name === selectedCharacter.name) + 1;
 	const invalidateUserInfo = useInvalidateUserInfo();
+	const { setIsOnboarding } = useAuthStore();
 
 	useHideBottomNav();
 
@@ -35,8 +37,10 @@ export default function Onboarding() {
 				characterId: characterId,
 			});
 		},
-		onSuccess: () => {
+		onSuccess: async () => {
 			setName(selectedCharacter.name);
+			setIsOnboarding(false);
+			await AsyncStorage.removeItem("isOnboardingNeeded");
 			router.push("/home");
 		},
 		onError: (error) => {

--- a/features/home/ui/TodayHistory.tsx
+++ b/features/home/ui/TodayHistory.tsx
@@ -6,7 +6,6 @@ import { getRecordById } from "@/features/record/api/getRecordById";
 import { useFeedbackTimer } from "@/shared/hooks/useFeedbackTimer";
 import { useAuthStore } from "@/shared/store/auth";
 import { useFeedbackTimerStore } from "@/shared/store/feedbackTimer";
-import { MyCharacter } from "@/shared/store/myCharacter";
 import { EmotionCard } from "@/shared/ui/EmotionCard";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
@@ -33,7 +32,6 @@ export function TodayHistory({ recordId, onMenuPress }: TodayHistoryProps) {
 	const { isWaitingForFeedback, remainingSeconds } =
 		useFeedbackTimer(journalIdString);
 	const { characterName: savedCharacterName } = useFeedbackTimerStore();
-	const { name: currentCharacterName } = MyCharacter();
 	const { data: record, isLoading: isRecordLoading } = useQuery({
 		queryKey: ["emotionRecord", recordId],
 		queryFn: () => getRecordById(recordId.toString()),
@@ -114,13 +112,11 @@ export function TodayHistory({ recordId, onMenuPress }: TodayHistoryProps) {
 
 	const characterImage = useMemo(() => {
 		if (isWaitingForFeedback || isFeedbackLoading) {
-			const characterToShow = savedCharacterName || currentCharacterName;
-			return getCharacterImage(characterToShow as CharacterName);
+			return getCharacterImage(savedCharacterName as CharacterName);
 		}
 		return getCharacterImage(feedbackData?.characterName as CharacterName);
 	}, [
 		feedbackData?.characterName,
-		currentCharacterName,
 		isWaitingForFeedback,
 		isFeedbackLoading,
 		savedCharacterName,

--- a/features/journal/ui/TodayHistory.tsx
+++ b/features/journal/ui/TodayHistory.tsx
@@ -7,7 +7,6 @@ import { getRecordById } from "@/features/record/api/getRecordById";
 import { useFeedbackTimer } from "@/shared/hooks/useFeedbackTimer";
 import { useAuthStore } from "@/shared/store/auth";
 import { useFeedbackTimerStore } from "@/shared/store/feedbackTimer";
-import { MyCharacter } from "@/shared/store/myCharacter";
 import type { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
@@ -25,7 +24,6 @@ export function TodayHistory({ recordId }: TodayHistoryProps) {
 	const journalIdString = String(recordId);
 	const { isWaitingForFeedback, remainingSeconds } =
 		useFeedbackTimer(journalIdString);
-	const { name: currentCharacterName } = MyCharacter();
 	const { characterName: savedCharacterName } = useFeedbackTimerStore();
 	const { data: record, isLoading: isRecordLoading } = useQuery({
 		queryKey: ["emotionRecord", recordId],
@@ -106,13 +104,11 @@ export function TodayHistory({ recordId }: TodayHistoryProps) {
 
 	const characterImage = useMemo(() => {
 		if (isWaitingForFeedback || isFeedbackLoading) {
-			const characterToShow = savedCharacterName || currentCharacterName;
-			return getCharacterImage(characterToShow as CharacterName);
+			return getCharacterImage(savedCharacterName as CharacterName);
 		}
 		return getCharacterImage(feedbackData?.characterName as CharacterName);
 	}, [
 		feedbackData?.characterName,
-		currentCharacterName,
 		isWaitingForFeedback,
 		isFeedbackLoading,
 		savedCharacterName,

--- a/features/login/api/appleLogin.ts
+++ b/features/login/api/appleLogin.ts
@@ -30,6 +30,7 @@ export const appleLogin = async (
 
 	await AsyncStorage.setItem("accessToken", accessToken);
 	await AsyncStorage.setItem("refreshToken", refreshToken);
+	await AsyncStorage.setItem("isOnboardingNeeded", String(isOnboardingNeeded));
 
 	const userEmail = await getUserInfo();
 	const defaultEmail = userEmail.email.split("@")[0];

--- a/features/login/api/kakaoLogin.ts
+++ b/features/login/api/kakaoLogin.ts
@@ -29,6 +29,7 @@ export const kakaoLogin = async (
 
 	await AsyncStorage.setItem("accessToken", accessToken);
 	await AsyncStorage.setItem("refreshToken", refreshToken);
+	await AsyncStorage.setItem("isOnboardingNeeded", String(isOnboardingNeeded));
 
 	const getKakaoProfile = async () => {
 		try {

--- a/features/login/ui/LoginButton.tsx
+++ b/features/login/ui/LoginButton.tsx
@@ -16,7 +16,7 @@ export function LoginButton() {
 	const ios = Platform.OS === "ios";
 	const router = useRouter();
 	const { pendingDestination, clearPendingDestination } = useDeepLinkStore();
-	const { setIsLoggedIn } = useAuthStore();
+	const { setIsLoggedIn, setIsOnboarding } = useAuthStore();
 
 	const {
 		animatedStyle: kakaoAnimatedStyle,
@@ -33,13 +33,18 @@ export function LoginButton() {
 		setIsLoggedIn(true);
 		registerForPushNotificationsAsync(); // 로그인 성공 후 FCM 토큰 등록/전송
 		console.log(isOnboardingNeeded);
+
 		if (isOnboardingNeeded) {
+			setIsOnboarding(true);
 			router.replace("/onboarding");
-		} else if (pendingDestination) {
-			router.replace(pendingDestination as Href);
-			clearPendingDestination();
 		} else {
-			router.replace("/home");
+			setIsOnboarding(false);
+			if (pendingDestination) {
+				router.replace(pendingDestination as Href);
+				clearPendingDestination();
+			} else {
+				router.replace("/home");
+			}
 		}
 	};
 

--- a/shared/api/axios.ts
+++ b/shared/api/axios.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from "@/shared/store/auth";
 import type { ApiResponse } from "@/shared/types";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import axios, {
@@ -56,9 +57,17 @@ instance.interceptors.response.use(
 					originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 					return instance(originalRequest);
 				} catch (_refreshError) {
+					// 리프레시 실패 시 로그인 페이지 이동
 					await AsyncStorage.multiRemove(["accessToken", "refreshToken"]);
+					useAuthStore.getState().setIsLoggedIn(false);
 					router.replace("/login");
+					return Promise.reject(_refreshError);
 				}
+			} else {
+				await AsyncStorage.multiRemove(["accessToken", "refreshToken"]);
+				useAuthStore.getState().setIsLoggedIn(false);
+				router.replace("/login");
+				return Promise.reject(error);
 			}
 		}
 

--- a/shared/store/auth.ts
+++ b/shared/store/auth.ts
@@ -3,9 +3,13 @@ import { create } from "zustand";
 interface AuthState {
 	isLoggedIn: boolean | null;
 	setIsLoggedIn: (isLoggedIn: boolean) => void;
+	isOnboarding: boolean;
+	setIsOnboarding: (isOnboarding: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
 	isLoggedIn: null,
 	setIsLoggedIn: (isLoggedIn) => set({ isLoggedIn }),
+	isOnboarding: false,
+	setIsOnboarding: (isOnboarding) => set({ isOnboarding }),
 }));

--- a/shared/store/feedbackTimer.ts
+++ b/shared/store/feedbackTimer.ts
@@ -33,7 +33,6 @@ export const useFeedbackTimerStore = create<FeedbackTimerState>((set) => ({
 				isTimerRunning: false,
 				targetJournalId: null,
 				timerEndTime: null,
-				characterName: null,
 			}),
 	},
 }));


### PR DESCRIPTION
## 🔥 PR 제목  
feat: 새 유저 온보딩 플로우 개선

## 📌 작업 내용  

> 새 유저가 로그인 후 온보딩 페이지에서 나갔다가 재시작하면 로그인 화면으로 돌아감
- isOnboardingNeeded를 AsyncStorage에 저장해 앱 재시작 시에도 유지
- 레이아웃에서 앱 시작시 asnycStorage에서 온보딩 상태를 확인

> 새 유저 온보딩에서 나갔다 재시작하여 온보딩 완료시 MyCharacter store가 서버 정보와 동기화되지 않아 피드백 로딩 중 최신 캐릭터가 표시됨 (츠츠로 기록 -> 루루로 변경 -> 피드백생성과 로딩이 츠츠 -> 루루의 피드백)
- 홈에서 유저정보를 가져와 캐릭터 정보 업데이트

> 리프레시 토큰이 없을 때 401 에러 발생 시 로그인 페이지로 리다이렉트되지 않음
- 리프레시 실패 시에도 토큰 제거 후 로그인 페이지로 리다이렉트, useAuthStore의 isLoggedIn 상태 업데이트


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  
아래 방법으로 테스트 해주시면 감사하겠습니다! (일단 저는 잘 됩니다)
1. 새계정 로그인 -> 온보딩 -> 홈화면으로 가는지
2. 새계정 로그인 -> 온보딩 페이지에서 앱 재시작 -> 온보딩 나오는지 -> 홈화면으로 넘어가는지
3. 2번으로 테스트 후 기록 테스트(ex.루루) -> 캐릭터 변경 -> 피드백 나오기 전까지 기록했던 캐릭터(루루)가 그대로 나오는지

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  
